### PR TITLE
Fix Buff Layout for Vertical Displays

### DIFF
--- a/src/entrypoints/buff.content/index.ts
+++ b/src/entrypoints/buff.content/index.ts
@@ -44,6 +44,9 @@ function addStorageListeners() {
     ExtensionStorage.hideFloatBar.watch((value) => {
         hideFloatBar(value ?? false);
     });
+    ExtensionStorage.layoutFix.watch((value) => {
+        applyLayoutFix(value ?? false);
+    });
 }
 
 function addMutationObserver() {
@@ -71,6 +74,11 @@ async function applyStaticAdjustments() {
     if (await ExtensionStorage.hideFloatBar.getValue()) {
         hideFloatBar(true);
     }
+
+    // apply layout fix
+    if (await ExtensionStorage.layoutFix.getValue()) {
+        applyLayoutFix(true);
+    }
 }
 
 function applyDarkMode(darkMode: boolean) {
@@ -79,4 +87,8 @@ function applyDarkMode(darkMode: boolean) {
 
 function hideFloatBar(hide: boolean) {
     document.querySelector('.floatbar')?.setAttribute('style', hide ? 'display: none;' : '');
+}
+
+function applyLayoutFix(layoutFix: boolean) {
+    document.body.classList.toggle('bb-layout-fix', layoutFix);
 }

--- a/src/entrypoints/buff.content/layout-fix.css
+++ b/src/entrypoints/buff.content/layout-fix.css
@@ -156,7 +156,7 @@
         flex: unset !important;
     }
 
-    .w-Search .i_Text {
+    .criteria.search_auto_grow .w-Search input.i_Text, .w-Search .i_Text {
         width: 175px !important;
     }
 
@@ -286,5 +286,117 @@
 }
 
 @media (min-width: 1100px) and (max-width: 1250px) {
-    /* TODO */
+    .l_Layout {
+        max-width: 1060px !important;
+    }
+
+    div.header-cont.l_Layout {
+        max-width: 1040px !important;
+    }
+
+    .header .logo {
+        margin-right: 35px !important;
+    }
+
+    body {
+        min-width: 1060px !important;
+    }
+
+    .focus-text {
+        margin-left: -580px !important;
+    }
+
+    .focus-pic {
+        margin-left: -150px !important;
+    }
+
+    @keyframes leftInC {
+        0% {
+            transform: translateX(50px);
+            opacity: .5
+        }
+
+        100% {
+            transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    @-webkit-keyframes leftInC {
+        0% {
+            -webkit-transform: translateX(50px);
+            opacity: .5
+        }
+
+        100% {
+            -webkit-transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    @keyframes rightInC {
+        0% {
+            transform: translateX(-50px);
+            opacity: .5
+        }
+
+        100% {
+            transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    @-webkit-keyframes rightInC {
+        0% {
+            -webkit-transform: translateX(-50px);
+            opacity: .5
+        }
+
+        100% {
+            -webkit-transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    .focus-slider-nav {
+        margin-left: -500px !important;
+    }
+
+    .h1z1-selType .item.w-SelType {
+        width: 6.8% !important;
+    }
+
+    /* Use 6 columns for Place Buy Order grid */
+    .list_card.list_card_small ul:not(#index-popular_goods-data-list-csgo) {
+        grid-template-columns: auto auto auto auto auto auto;
+    }
+
+    .user-header > div {
+        padding-left: 75px !important;
+    }
+
+    .user-header .col {
+        width: 200px !important;
+        margin-right: 50px !important;
+    }
+
+    .change .list_tb td {
+        padding: 10px 6px !important;
+    }
+
+    #bookmark_sell_order_list table.list_tb tr td:last-child > * {
+        padding: 0 6px !important;
+    }
+
+    .footer {
+        min-width: 1060px !important;
+    }
+
+    .footer .guide .guide-section {
+        margin-right: 75px !important;
+    }
+
+    .footer .guide .guide-section:first-child {
+        margin-left: 100px !important;
+    }
 }

--- a/src/entrypoints/buff.content/layout-fix.css
+++ b/src/entrypoints/buff.content/layout-fix.css
@@ -1,0 +1,161 @@
+/* show horizontal scrollbars if needed */
+body::-webkit-scrollbar:horizontal {
+    height: 10px;
+}
+
+@media (min-width: 1000px) and (max-width: 1100px) {
+    .l_Layout {
+        max-width: 980px !important;
+    }
+
+    .header .logo {
+        margin-right: 25px !important;
+    }
+
+    body {
+        min-width: 980px !important;
+    }
+
+    .focus {
+        min-width: unset !important;
+    }
+
+    .focus-text {
+        margin-left: -565px !important;
+        animation: rightInC .5s 0s ease-in-out 1 forwards !important;
+        -webkit-animation: rightInC .5s 0s ease-in-out 1 forwards !important;
+    }
+
+    .focus-pic {
+        z-index: -500;
+        margin-left: -150px !important;
+        animation: leftInC .5s 0s ease-in-out 1 forwards !important;
+        -webkit-animation: leftInC .5s 0s ease-in-out 1 forwards !important;
+    }
+
+    @keyframes leftInC {
+        0% {
+            transform: translateX(25px);
+            opacity: .5
+        }
+
+        100% {
+            transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    @-webkit-keyframes leftInC {
+        0% {
+            -webkit-transform: translateX(25px);
+            opacity: .5
+        }
+
+        100% {
+            -webkit-transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    @keyframes rightInC {
+        0% {
+            transform: translateX(-25px);
+            opacity: .5
+        }
+
+        100% {
+            transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    @-webkit-keyframes rightInC {
+        0% {
+            -webkit-transform: translateX(-25px);
+            opacity: .5
+        }
+
+        100% {
+            -webkit-transform: translateX(0);
+            opacity: 1
+        }
+    }
+
+    .focus-slider-nav {
+        margin-left: -485px !important;
+    }
+
+    .list_card ul {
+        width: unset !important;
+    }
+
+    .list_card ul:not(#index-popular_goods-data-list-csgo) {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 210px);
+        grid-gap: 28px;
+        justify-content: center;
+    }
+
+    .area1, .area2, .area3 {
+        height: unset !important;
+        background-size: cover !important;
+        padding: 0 !important;
+    }
+
+    .market-header {
+        width: unset !important;
+    }
+
+    .h1z1-selType {
+        margin: 0 15px !important;
+    }
+
+    .h1z1-selType .item.w-SelType {
+        width: 6.5% !important;
+    }
+
+    .criteria {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+    }
+
+    .criteria .w-SelHero, .criteria .w-Select, .criteria .w-Select-Multi {
+        margin-right: 0 !important;
+    }
+
+    .criteria .l_Right {
+        width: 100%;
+    }
+
+    .criteria .l_Right .w-Search {
+        margin-top: 12px;
+        float: right;
+    }
+
+    .list_card li {
+        margin: 0 !important;
+    }
+
+    .footer {
+        min-width: 980px !important;
+    }
+
+    .footer .guide {
+        width: unset !important;
+        padding-left: 0 !important;
+    }
+
+    .footer .guide .guide-section {
+        width: unset !important;
+        margin-right: 60px !important;
+    }
+
+    .footer .guide .guide-section:first-child {
+        margin-left: 60px !important;
+    }
+}
+
+@media (min-width: 1100px) and (max-width: 1250px) {
+    /* TODO */
+}

--- a/src/entrypoints/buff.content/layout-fix.css
+++ b/src/entrypoints/buff.content/layout-fix.css
@@ -326,7 +326,7 @@
         padding: 30px 0 !important;
     }
 
-    .detail-tab-cont > div:nth-child(2) {
+    .detail-tab-cont > div:nth-child(2):has(+ div#tag-price-chart) {
         padding: 30px 0 !important;
         margin: 0 !important;
         margin-right: 75px !important;

--- a/src/entrypoints/buff.content/layout-fix.css
+++ b/src/entrypoints/buff.content/layout-fix.css
@@ -1,11 +1,17 @@
-/* show horizontal scrollbars if needed */
-body::-webkit-scrollbar:horizontal {
-    height: 10px;
+@media (max-width: 1250px) {
+    /* show horizontal scrollbars if needed */
+    body::-webkit-scrollbar:horizontal {
+        height: 10px;
+    }
 }
 
-@media (min-width: 1000px) and (max-width: 1100px) {
+@media (min-width: 1000px) and (max-width: 1250px) {
     .l_Layout {
         max-width: 980px !important;
+    }
+
+    div.header-cont.l_Layout {
+        max-width: 950px !important;
     }
 
     .header .logo {
@@ -91,9 +97,21 @@ body::-webkit-scrollbar:horizontal {
 
     .list_card ul:not(#index-popular_goods-data-list-csgo) {
         display: grid;
-        grid-template-columns: repeat(auto-fill, 210px);
-        grid-gap: 28px;
+        grid-template-columns: auto auto auto auto;
+        gap: 0;
         justify-content: center;
+    }
+
+    /* Use 5 columns for Place Buy Order grid */
+    .list_card.list_card_small ul:not(#index-popular_goods-data-list-csgo) {
+        display: grid;
+        grid-template-columns: auto auto auto auto auto;
+        gap: 0;
+        justify-content: center;
+    }
+
+    .list_card ul:not(#index-popular_goods-data-list-csgo) li {
+        margin: 11px !important;
     }
 
     .area1, .area2, .area3 {
@@ -117,24 +135,135 @@ body::-webkit-scrollbar:horizontal {
     .criteria {
         display: flex;
         flex-wrap: wrap;
-        justify-content: space-between;
+        justify-content: flex-start;
+        padding-bottom: 2px !important;
     }
 
-    .criteria .w-SelHero, .criteria .w-Select, .criteria .w-Select-Multi {
-        margin-right: 0 !important;
+    .criteria .w-SelHero, .criteria .w-Select, .criteria .w-Select-Multi, .criteria .w-SelDate {
+        margin-bottom: 12px;
     }
 
     .criteria .l_Right {
-        width: 100%;
+        margin-left: auto;
+        margin-bottom: 12px;
     }
 
     .criteria .l_Right .w-Search {
-        margin-top: 12px;
         float: right;
+    }
+
+    .criteria.search_auto_grow .l_Right {
+        flex: unset !important;
+    }
+
+    .w-Search .i_Text {
+        width: 175px !important;
     }
 
     .list_card li {
         margin: 0 !important;
+    }
+
+    .market-header .cont-tab, .market-header .criteria, .market-header .tab-games {
+        margin: 0 15px;
+    }
+
+    .cont-tab li {
+        margin-right: 25px !important;
+    }
+
+    .cont-tab li:last-child {
+        margin-right: 0 !important;
+    }
+
+    .market-header div.l_Right.export-btns.brief-info span {
+        max-width: 150px;
+    }
+
+    div.l_Right.export-btns.brief-info span {
+        display: inline-block;
+    }
+
+    .detail-tab-cont .sold-count {
+        padding-left: 0 !important;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .count-item {
+        width: unset !important;
+        margin: 0 12px 24px 12px !important;
+    }
+
+    .count-item li:not(.split) {
+        width: 135px !important;
+    }
+
+    .user-header {
+        width: unset !important;
+    }
+
+    .user-header > div {
+        padding-left: 50px !important;
+    }
+
+    .user-header .col {
+        width: 185px !important;
+        margin-right: 35px !important;
+    }
+
+    .cont_main {
+        margin-left: 230px !important;
+    }
+
+    .cont_panel {
+        width: 210px !important;
+    }
+
+    .cont_panel .my-menu li {
+        width: 210px !important;
+    }
+
+    .cont_panel .my-menu li a {
+        padding: 0 35px !important;
+    }
+
+    .g-w940 {
+        width: unset !important;
+    }
+
+    .change .list_tb td {
+        padding: 10px 3px !important;
+    }
+
+    .list_tb td {
+        height: unset !important;
+    }
+
+    .user-record {
+        width: fit-content;
+    }
+
+    #bookmark_sell_order_list table.list_tb tr td p {
+        white-space: nowrap;
+    }
+
+    #bookmark_sell_order_list table.list_tb tr td p.c_Gray.f_12px.gMT6 {
+        white-space: break-spaces;
+    }
+
+    #bookmark_sell_order_list table.list_tb tr td a {
+        white-space: nowrap;
+    }
+
+    #bookmark_sell_order_list table.list_tb tr td:last-child > * {
+        padding: 0 3px !important;
+        margin: 1px !important;
+    }
+
+    #bookmark_sell_order_list table.list_tb tr td:last-child > *:not(:last-child) {
+        margin-bottom: 2px !important;
     }
 
     .footer {

--- a/src/entrypoints/buff.content/layout-fix.css
+++ b/src/entrypoints/buff.content/layout-fix.css
@@ -6,485 +6,488 @@
 }
 
 @media (min-width: 1000px) and (max-width: 1250px) {
-    .l_Layout {
-        max-width: 980px !important;
-    }
-
-    div.header-cont.l_Layout {
-        max-width: 950px !important;
-    }
-
-    .header .logo {
-        margin-right: 25px !important;
-    }
-
-    body {
+    body.bb-layout-fix {
         min-width: 980px !important;
-    }
 
-    .focus {
-        min-width: unset !important;
-    }
-
-    .focus-text {
-        margin-left: -565px !important;
-        animation: rightInC .5s 0s ease-in-out 1 forwards !important;
-        -webkit-animation: rightInC .5s 0s ease-in-out 1 forwards !important;
-    }
-
-    .focus-pic {
-        z-index: -500;
-        margin-left: -150px !important;
-        animation: leftInC .5s 0s ease-in-out 1 forwards !important;
-        -webkit-animation: leftInC .5s 0s ease-in-out 1 forwards !important;
-    }
-
-    @keyframes leftInC {
-        0% {
-            transform: translateX(25px);
-            opacity: .5
+        .l_Layout {
+            max-width: 980px !important;
         }
 
-        100% {
-            transform: translateX(0);
-            opacity: 1
-        }
-    }
-
-    @-webkit-keyframes leftInC {
-        0% {
-            -webkit-transform: translateX(25px);
-            opacity: .5
+        div.header-cont.l_Layout {
+            max-width: 950px !important;
         }
 
-        100% {
-            -webkit-transform: translateX(0);
-            opacity: 1
-        }
-    }
-
-    @keyframes rightInC {
-        0% {
-            transform: translateX(-25px);
-            opacity: .5
+        .header .logo {
+            margin-right: 25px !important;
         }
 
-        100% {
-            transform: translateX(0);
-            opacity: 1
-        }
-    }
-
-    @-webkit-keyframes rightInC {
-        0% {
-            -webkit-transform: translateX(-25px);
-            opacity: .5
+        .focus {
+            min-width: unset !important;
         }
 
-        100% {
-            -webkit-transform: translateX(0);
-            opacity: 1
+        .focus-text {
+            margin-left: -565px !important;
+            animation: rightInC .5s 0s ease-in-out 1 forwards !important;
+            -webkit-animation: rightInC .5s 0s ease-in-out 1 forwards !important;
         }
-    }
 
-    .focus-slider-nav {
-        margin-left: -485px !important;
-    }
+        .focus-pic {
+            z-index: -500;
+            margin-left: -150px !important;
+            animation: leftInC .5s 0s ease-in-out 1 forwards !important;
+            -webkit-animation: leftInC .5s 0s ease-in-out 1 forwards !important;
+        }
 
-    .list_card ul {
-        width: unset !important;
-    }
+        @keyframes leftInC {
+            0% {
+                transform: translateX(25px);
+                opacity: .5
+            }
 
-    .list_card ul:not(#index-popular_goods-data-list-csgo) {
-        display: grid;
-        grid-template-columns: auto auto auto auto;
-        gap: 0;
-        justify-content: center;
-    }
+            100% {
+                transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    /* Use 5 columns for Place Buy Order grid */
-    .list_card.list_card_small ul:not(#index-popular_goods-data-list-csgo) {
-        display: grid;
-        grid-template-columns: auto auto auto auto auto;
-        gap: 0;
-        justify-content: center;
-    }
+        @-webkit-keyframes leftInC {
+            0% {
+                -webkit-transform: translateX(25px);
+                opacity: .5
+            }
 
-    .list_card ul:not(#index-popular_goods-data-list-csgo) li {
-        margin: 11px !important;
-    }
+            100% {
+                -webkit-transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    .area1, .area2, .area3 {
-        height: unset !important;
-        background-size: cover !important;
-        padding: 0 !important;
-    }
+        @keyframes rightInC {
+            0% {
+                transform: translateX(-25px);
+                opacity: .5
+            }
 
-    .market-header {
-        width: unset !important;
-    }
+            100% {
+                transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    .h1z1-selType {
-        margin: 0 15px !important;
-    }
+        @-webkit-keyframes rightInC {
+            0% {
+                -webkit-transform: translateX(-25px);
+                opacity: .5
+            }
 
-    .h1z1-selType .item.w-SelType {
-        width: 6.5% !important;
-    }
+            100% {
+                -webkit-transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    .criteria {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-        padding-bottom: 2px !important;
-    }
+        .focus-slider-nav {
+            margin-left: -485px !important;
+        }
 
-    .criteria .w-SelHero, .criteria .w-Select, .criteria .w-Select-Multi, .criteria .w-SelDate {
-        margin-bottom: 12px;
-    }
+        .list_card ul {
+            width: unset !important;
+        }
 
-    .criteria .l_Right {
-        margin-left: auto;
-        margin-bottom: 12px;
-    }
+        .list_card ul:not(#index-popular_goods-data-list-csgo) {
+            display: grid;
+            grid-template-columns: auto auto auto auto;
+            gap: 0;
+            justify-content: center;
+        }
 
-    .criteria .l_Right .w-Search {
-        float: right;
-    }
+        /* Use 5 columns for Place Buy Order grid */
 
-    .criteria.search_auto_grow .l_Right {
-        flex: unset !important;
-    }
+        .list_card.list_card_small ul:not(#index-popular_goods-data-list-csgo) {
+            display: grid;
+            grid-template-columns: auto auto auto auto auto;
+            gap: 0;
+            justify-content: center;
+        }
 
-    .criteria.search_auto_grow .w-Search input.i_Text, .w-Search .i_Text {
-        width: 175px !important;
-    }
+        .list_card ul:not(#index-popular_goods-data-list-csgo) li {
+            margin: 11px !important;
+        }
 
-    .list_card li {
-        margin: 0 !important;
-    }
+        .area1, .area2, .area3 {
+            height: unset !important;
+            background-size: cover !important;
+            padding: 0 !important;
+        }
 
-    .market-header .cont-tab, .market-header .criteria, .market-header .tab-games {
-        margin: 0 15px;
-    }
+        .market-header {
+            width: unset !important;
+        }
 
-    .cont-tab li {
-        margin-right: 25px !important;
-    }
+        .h1z1-selType {
+            margin: 0 15px !important;
+        }
 
-    .cont-tab li:last-child {
-        margin-right: 0 !important;
-    }
+        .h1z1-selType .item.w-SelType {
+            width: 6.5% !important;
+        }
 
-    .market-header div.l_Right.export-btns.brief-info span {
-        max-width: 150px;
-    }
+        .criteria {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            padding-bottom: 2px !important;
+        }
 
-    div.l_Right.export-btns.brief-info span {
-        display: inline-block;
-    }
+        .criteria .w-SelHero, .criteria .w-Select, .criteria .w-Select-Multi, .criteria .w-SelDate {
+            margin-bottom: 12px;
+        }
 
-    .detail-tab-cont .sold-count {
-        padding-left: 0 !important;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-    }
+        .criteria .l_Right {
+            margin-left: auto;
+            margin-bottom: 12px;
+        }
 
-    .count-item {
-        width: unset !important;
-        margin: 0 12px 24px 12px !important;
-    }
+        .criteria .l_Right .w-Search {
+            float: right;
+        }
 
-    .count-item li:not(.split) {
-        width: 135px !important;
-    }
+        .criteria.search_auto_grow .l_Right {
+            flex: unset !important;
+        }
 
-    .user-header {
-        width: unset !important;
-    }
+        .criteria.search_auto_grow .w-Search input.i_Text, .w-Search .i_Text {
+            width: 175px !important;
+        }
 
-    .user-header > div {
-        padding-left: 50px !important;
-    }
+        .list_card li {
+            margin: 0 !important;
+        }
 
-    .user-header .col {
-        width: 185px !important;
-        margin-right: 35px !important;
-    }
+        .market-header .cont-tab, .market-header .criteria, .market-header .tab-games {
+            margin: 0 15px;
+        }
 
-    .cont_main {
-        margin-left: 230px !important;
-    }
+        .cont-tab li {
+            margin-right: 25px !important;
+        }
 
-    .cont_panel {
-        width: 210px !important;
-    }
+        .cont-tab li:last-child {
+            margin-right: 0 !important;
+        }
 
-    .cont_panel .my-menu li {
-        width: 210px !important;
-    }
+        .market-header div.l_Right.export-btns.brief-info span {
+            max-width: 150px;
+        }
 
-    .cont_panel .my-menu li a {
-        padding: 0 35px !important;
-    }
+        div.l_Right.export-btns.brief-info span {
+            display: inline-block;
+        }
 
-    .g-w940 {
-        width: unset !important;
-    }
+        .detail-tab-cont .sold-count {
+            padding-left: 0 !important;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
 
-    .change .list_tb td {
-        padding: 10px 3px !important;
-    }
+        .count-item {
+            width: unset !important;
+            margin: 0 12px 24px 12px !important;
+        }
 
-    .list_tb td {
-        height: unset !important;
-    }
+        .count-item li:not(.split) {
+            width: 135px !important;
+        }
 
-    .user-record {
-        width: fit-content;
-    }
+        .user-header {
+            width: unset !important;
+        }
 
-    #bookmark_sell_order_list table.list_tb tr td p {
-        white-space: nowrap;
-    }
+        .user-header > div {
+            padding-left: 50px !important;
+        }
 
-    #bookmark_sell_order_list table.list_tb tr td p.c_Gray.f_12px.gMT6 {
-        white-space: break-spaces;
-    }
+        .user-header .col {
+            width: 185px !important;
+            margin-right: 35px !important;
+        }
 
-    #bookmark_sell_order_list table.list_tb tr td a {
-        white-space: nowrap;
-    }
+        .cont_main {
+            margin-left: 230px !important;
+        }
 
-    #bookmark_sell_order_list table.list_tb tr td:last-child > * {
-        padding: 0 3px !important;
-        margin: 1px !important;
-    }
+        .cont_panel {
+            width: 210px !important;
+        }
 
-    #bookmark_sell_order_list table.list_tb tr td:last-child > *:not(:last-child) {
-        margin-bottom: 2px !important;
-    }
+        .cont_panel .my-menu li {
+            width: 210px !important;
+        }
 
-    .detail-header {
-        width: 980px !important;
-    }
+        .cont_panel .my-menu li a {
+            padding: 0 35px !important;
+        }
 
-    .relative-goods {
-        padding: 10px 25px !important;
-    }
+        .g-w940 {
+            width: unset !important;
+        }
 
-    .relative-goods div.scope-btns {
-        display: flex;
-        justify-content: flex-start;
-        flex-wrap: wrap;
-    }
+        .change .list_tb td {
+            padding: 10px 3px !important;
+        }
 
-    .des_row .desc_content {
-        width: 75% !important
-    }
+        .list_tb td {
+            height: unset !important;
+        }
 
-    .betterbuff-forcereload.i_Btn.i_Btn_mid.i_Btn_sub {
-        margin-bottom: 12px !important;
-        height: 32px !important;
-    }
+        .user-record {
+            width: fit-content;
+        }
 
-    .l_Right .w-Checkbox#preview_screenshots {
-        margin-bottom: 12px;
-    }
+        #bookmark_sell_order_list table.list_tb tr td p {
+            white-space: nowrap;
+        }
 
-    .l_Right .w-Counter#j_counter {
-        margin-bottom: 12px;
-    }
+        #bookmark_sell_order_list table.list_tb tr td p.c_Gray.f_12px.gMT6 {
+            white-space: break-spaces;
+        }
 
-    /*
-    TODO: To achieve the Buff gallery original (pinterest) look we would need CSS masonry layout:
-    https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout
-    Let's pray that after 3 years this will eventually be supported by modern browsers.
-     */
-    .pinterest-list {
-        height: unset !important;
-        display: grid;
-        grid-template-columns: auto auto auto auto;
-        justify-content: space-between;
-        align-items: start;
-    }
+        #bookmark_sell_order_list table.list_tb tr td a {
+            white-space: nowrap;
+        }
 
-    .pinterest-item {
-        position: relative !important;
-        top: unset !important;
-        left: unset !important;
-        margin-bottom: 22px !important;
-    }
+        #bookmark_sell_order_list table.list_tb tr td:last-child > * {
+            padding: 0 3px !important;
+            margin: 1px !important;
+        }
 
-    .detail-tab-cont .w-Switcher_tab span {
-        margin-right: 20px !important;
-    }
+        #bookmark_sell_order_list table.list_tb tr td:last-child > *:not(:last-child) {
+            margin-bottom: 2px !important;
+        }
 
-    .detail-tab-cont .w-Switcher.w-Switcher_tab#history-type {
-        margin-left: 75px !important;
-        padding: 30px 0 !important;
-    }
+        .detail-header {
+            width: 980px !important;
+        }
 
-    .detail-tab-cont > div:nth-child(2):has(+ div#tag-price-chart) {
-        padding: 30px 0 !important;
-        margin: 0 !important;
-        margin-right: 75px !important;
-    }
+        .relative-goods {
+            padding: 10px 25px !important;
+        }
 
-    .map_price {
-        padding: 20px 15px !important;
-    }
+        .relative-goods div.scope-btns {
+            display: flex;
+            justify-content: flex-start;
+            flex-wrap: wrap;
+        }
 
-    #tag-price-chart canvas {
-        width: 950px !important;
-        height: 475px !important;
-    }
+        .des_row .desc_content {
+            width: 75% !important
+        }
 
-    .footer {
-        min-width: 980px !important;
-    }
+        .betterbuff-forcereload.i_Btn.i_Btn_mid.i_Btn_sub {
+            margin-bottom: 12px !important;
+            height: 32px !important;
+        }
 
-    .footer .guide {
-        width: unset !important;
-        padding-left: 0 !important;
-    }
+        .l_Right .w-Checkbox#preview_screenshots {
+            margin-bottom: 12px;
+        }
 
-    .footer .guide .guide-section {
-        width: unset !important;
-        margin-right: 60px !important;
-    }
+        .l_Right .w-Counter#j_counter {
+            margin-bottom: 12px;
+        }
 
-    .footer .guide .guide-section:first-child {
-        margin-left: 60px !important;
+        /*
+        TODO: To achieve the Buff gallery original (pinterest) look we would need CSS masonry layout:
+        https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout
+        Let's pray that after 3 years this will eventually be supported by modern browsers.
+         */
+
+        .pinterest-list {
+            height: unset !important;
+            display: grid;
+            grid-template-columns: auto auto auto auto;
+            justify-content: space-between;
+            align-items: start;
+        }
+
+        .pinterest-item {
+            position: relative !important;
+            top: unset !important;
+            left: unset !important;
+            margin-bottom: 22px !important;
+        }
+
+        .detail-tab-cont .w-Switcher_tab span {
+            margin-right: 20px !important;
+        }
+
+        .detail-tab-cont .w-Switcher.w-Switcher_tab#history-type {
+            margin-left: 75px !important;
+            padding: 30px 0 !important;
+        }
+
+        .detail-tab-cont > div:nth-child(2):has(+ div#tag-price-chart) {
+            padding: 30px 0 !important;
+            margin: 0 !important;
+            margin-right: 75px !important;
+        }
+
+        .map_price {
+            padding: 20px 15px !important;
+        }
+
+        #tag-price-chart canvas {
+            width: 950px !important;
+            height: 475px !important;
+        }
+
+        .footer {
+            min-width: 980px !important;
+        }
+
+        .footer .guide {
+            width: unset !important;
+            padding-left: 0 !important;
+        }
+
+        .footer .guide .guide-section {
+            width: unset !important;
+            margin-right: 60px !important;
+        }
+
+        .footer .guide .guide-section:first-child {
+            margin-left: 60px !important;
+        }
     }
 }
 
 @media (min-width: 1100px) and (max-width: 1250px) {
-    .l_Layout {
-        max-width: 1060px !important;
-    }
-
-    div.header-cont.l_Layout {
-        max-width: 1040px !important;
-    }
-
-    .header .logo {
-        margin-right: 35px !important;
-    }
-
-    body {
+    body.bb-layout-fix {
         min-width: 1060px !important;
-    }
 
-    .focus-text {
-        margin-left: -580px !important;
-    }
-
-    .focus-pic {
-        margin-left: -150px !important;
-    }
-
-    @keyframes leftInC {
-        0% {
-            transform: translateX(50px);
-            opacity: .5
+        .l_Layout {
+            max-width: 1060px !important;
         }
 
-        100% {
-            transform: translateX(0);
-            opacity: 1
-        }
-    }
-
-    @-webkit-keyframes leftInC {
-        0% {
-            -webkit-transform: translateX(50px);
-            opacity: .5
+        div.header-cont.l_Layout {
+            max-width: 1040px !important;
         }
 
-        100% {
-            -webkit-transform: translateX(0);
-            opacity: 1
-        }
-    }
-
-    @keyframes rightInC {
-        0% {
-            transform: translateX(-50px);
-            opacity: .5
+        .header .logo {
+            margin-right: 35px !important;
         }
 
-        100% {
-            transform: translateX(0);
-            opacity: 1
-        }
-    }
-
-    @-webkit-keyframes rightInC {
-        0% {
-            -webkit-transform: translateX(-50px);
-            opacity: .5
+        .focus-text {
+            margin-left: -580px !important;
         }
 
-        100% {
-            -webkit-transform: translateX(0);
-            opacity: 1
+        .focus-pic {
+            margin-left: -150px !important;
         }
-    }
 
-    .focus-slider-nav {
-        margin-left: -500px !important;
-    }
+        @keyframes leftInC {
+            0% {
+                transform: translateX(50px);
+                opacity: .5
+            }
 
-    .h1z1-selType .item.w-SelType {
-        width: 6.8% !important;
-    }
+            100% {
+                transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    /* Use 6 columns for Place Buy Order grid */
-    .list_card.list_card_small ul:not(#index-popular_goods-data-list-csgo) {
-        grid-template-columns: auto auto auto auto auto auto;
-    }
+        @-webkit-keyframes leftInC {
+            0% {
+                -webkit-transform: translateX(50px);
+                opacity: .5
+            }
 
-    .user-header > div {
-        padding-left: 75px !important;
-    }
+            100% {
+                -webkit-transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    .user-header .col {
-        width: 200px !important;
-        margin-right: 50px !important;
-    }
+        @keyframes rightInC {
+            0% {
+                transform: translateX(-50px);
+                opacity: .5
+            }
 
-    .change .list_tb td {
-        padding: 10px 6px !important;
-    }
+            100% {
+                transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    #bookmark_sell_order_list table.list_tb tr td:last-child > * {
-        padding: 0 6px !important;
-    }
+        @-webkit-keyframes rightInC {
+            0% {
+                -webkit-transform: translateX(-50px);
+                opacity: .5
+            }
 
-    .detail-header {
-        width: 1060px !important;
-    }
+            100% {
+                -webkit-transform: translateX(0);
+                opacity: 1
+            }
+        }
 
-    .map_price {
-        padding: 20px 30px !important;
-    }
+        .focus-slider-nav {
+            margin-left: -500px !important;
+        }
 
-    #tag-price-chart canvas {
-        width: 1000px !important;
-        height: 500px !important;
-    }
+        .h1z1-selType .item.w-SelType {
+            width: 6.8% !important;
+        }
 
-    .footer {
-        min-width: 1060px !important;
-    }
+        /* Use 6 columns for Place Buy Order grid */
 
-    .footer .guide .guide-section {
-        margin-right: 75px !important;
-    }
+        .list_card.list_card_small ul:not(#index-popular_goods-data-list-csgo) {
+            grid-template-columns: auto auto auto auto auto auto;
+        }
 
-    .footer .guide .guide-section:first-child {
-        margin-left: 100px !important;
+        .user-header > div {
+            padding-left: 75px !important;
+        }
+
+        .user-header .col {
+            width: 200px !important;
+            margin-right: 50px !important;
+        }
+
+        .change .list_tb td {
+            padding: 10px 6px !important;
+        }
+
+        #bookmark_sell_order_list table.list_tb tr td:last-child > * {
+            padding: 0 6px !important;
+        }
+
+        .detail-header {
+            width: 1060px !important;
+        }
+
+        .map_price {
+            padding: 20px 30px !important;
+        }
+
+        #tag-price-chart canvas {
+            width: 1000px !important;
+            height: 500px !important;
+        }
+
+        .footer {
+            min-width: 1060px !important;
+        }
+
+        .footer .guide .guide-section {
+            margin-right: 75px !important;
+        }
+
+        .footer .guide .guide-section:first-child {
+            margin-left: 100px !important;
+        }
     }
 }

--- a/src/entrypoints/buff.content/layout-fix.css
+++ b/src/entrypoints/buff.content/layout-fix.css
@@ -266,6 +266,81 @@
         margin-bottom: 2px !important;
     }
 
+    .detail-header {
+        width: 980px !important;
+    }
+
+    .relative-goods {
+        padding: 10px 25px !important;
+    }
+
+    .relative-goods div.scope-btns {
+        display: flex;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .des_row .desc_content {
+        width: 75% !important
+    }
+
+    .betterbuff-forcereload.i_Btn.i_Btn_mid.i_Btn_sub {
+        margin-bottom: 12px !important;
+        height: 32px !important;
+    }
+
+    .l_Right .w-Checkbox#preview_screenshots {
+        margin-bottom: 12px;
+    }
+
+    .l_Right .w-Counter#j_counter {
+        margin-bottom: 12px;
+    }
+
+    /*
+    TODO: To achieve the Buff gallery original (pinterest) look we would need CSS masonry layout:
+    https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout
+    Let's pray that after 3 years this will eventually be supported by modern browsers.
+     */
+    .pinterest-list {
+        height: unset !important;
+        display: grid;
+        grid-template-columns: auto auto auto auto;
+        justify-content: space-between;
+        align-items: start;
+    }
+
+    .pinterest-item {
+        position: relative !important;
+        top: unset !important;
+        left: unset !important;
+        margin-bottom: 22px !important;
+    }
+
+    .detail-tab-cont .w-Switcher_tab span {
+        margin-right: 20px !important;
+    }
+
+    .detail-tab-cont .w-Switcher.w-Switcher_tab#history-type {
+        margin-left: 75px !important;
+        padding: 30px 0 !important;
+    }
+
+    .detail-tab-cont > div:nth-child(2) {
+        padding: 30px 0 !important;
+        margin: 0 !important;
+        margin-right: 75px !important;
+    }
+
+    .map_price {
+        padding: 20px 15px !important;
+    }
+
+    #tag-price-chart canvas {
+        width: 950px !important;
+        height: 475px !important;
+    }
+
     .footer {
         min-width: 980px !important;
     }
@@ -386,6 +461,19 @@
 
     #bookmark_sell_order_list table.list_tb tr td:last-child > * {
         padding: 0 6px !important;
+    }
+
+    .detail-header {
+        width: 1060px !important;
+    }
+
+    .map_price {
+        padding: 20px 30px !important;
+    }
+
+    #tag-price-chart canvas {
+        width: 1000px !important;
+        height: 500px !important;
     }
 
     .footer {

--- a/src/entrypoints/injection.content.ts
+++ b/src/entrypoints/injection.content.ts
@@ -1,4 +1,5 @@
 import './buff.content/style.css';
+import './buff.content/layout-fix.css';
 
 export default defineContentScript({
     matches: ["*://*.buff.163.com/*"],

--- a/src/lib/pages/Main.svelte
+++ b/src/lib/pages/Main.svelte
@@ -22,6 +22,7 @@
         <SettingPaymentMethods bind:showModal={showModal}/>
         <SettingCheckbox text="Show Big Previews" storage={ExtensionStorage.showBigPreviews} dataTip="Show large item screenshots on image hover." />
         <SettingCheckbox text="Hide Floating Bar" storage={ExtensionStorage.hideFloatBar} dataTip="Hide the floating bar on the right site." />
+        <SettingCheckbox text="Fix Website Layout" storage={ExtensionStorage.layoutFix} dataTip="Fixes the Buff website's layout for vertical/smaller displays." />
         <SettingCheckbox text="Data Protection" storage={ExtensionStorage.dataProtection} dataTip="Blur privacy-relevant data in your account settings page. Relevant if you are screen-sharing or streaming." />
         <SettingListingOptions text="Listing Options" dataTip="Actions displayed under each listing on the corresponding item page. Requires a page reload." />
         <ListingDifference />

--- a/src/lib/util/storage.ts
+++ b/src/lib/util/storage.ts
@@ -15,6 +15,7 @@ export function setWindowG(g: BuffTypes.G) {
 export const defaultStorage = {
     enabled: true,
     darkMode: false,
+    layoutFix: false,
     hideFloatBar: false,
     showBigPreviews: false,
     dataProtection: false,
@@ -63,6 +64,13 @@ export namespace ExtensionStorage {
         'local:hideFloatBar',
         {
             defaultValue: defaultStorage.hideFloatBar,
+        },
+    );
+
+    export const layoutFix = storage.defineItem<IStorage['layoutFix']>(
+        'local:layoutFix',
+        {
+            defaultValue: defaultStorage.layoutFix,
         },
     );
 


### PR DESCRIPTION
The Buff.163 website's style is horribly unresponsive and basically breaks for any screen with a width less than 1250px. They also hide any horizontal scrollbars due to setting their height to 0px (probably an oversight on their end).

This PR aims to fix the style on screens with a viewport size of less than 1250px. For any screens above this threshold, no CSS rules will be applied, leaving the original layout untouched.

For screens with a width less than 1000px, the only change will be the display of a horizontal scrollbar at the bottom of the page just so that the page doesn't become actually unusable.

For screens with a width between 1000px and 1250px, I checked basically every individual Buff.163 sub-page and manually fixed the CSS until it looked as best as possible.

## TODOs
- [x] Check layout for screen widths between 1100px and 1250px and possibly make minor adjustments to take advantage of extra width

## Examples
### Before 
<img src="https://github.com/GODrums/BetterBuff/assets/22775065/464d257f-e11e-44a5-af11-d471bb56b68a" height="500">
<img src="https://github.com/GODrums/BetterBuff/assets/22775065/66c459cc-d7e2-4972-92ff-afd114609cbf" height="500">

### After
<img src="https://github.com/GODrums/BetterBuff/assets/22775065/e3d917f3-23a9-4b38-8651-dc18a714ada4" height="500">
<img src="https://github.com/GODrums/BetterBuff/assets/22775065/fa994390-03a6-4ac2-ab85-fc4d3e3c6ed0" height="500">
